### PR TITLE
Add hosts file option

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,15 @@ configured as remote VTEP endpoints.
 ## Usage
 
 ```
-python update_vtep.py -u <username> [--use-eapi] [--verify-ssl] <host1> <host2> [host3 ...]
+python update_vtep.py -u <username> [--use-eapi] [--verify-ssl] [--hosts-file FILE] <host1> <host2> [host3 ...]
 ```
 
 The script prompts for the password. At least two hosts must be supplied.
 Each switch will have all other hosts added to its flood list.
+
+Hosts can also be read from a file using `--hosts-file`, with one hostname or IP
+per line. Hosts provided on the command line are combined with those read from
+the file.
 
 Example:
 

--- a/tests/test_update_vtep.py
+++ b/tests/test_update_vtep.py
@@ -56,6 +56,12 @@ class ParseArgsTest(unittest.TestCase):
         self.assertTrue(args.verify_ssl)
         self.assertEqual(args.hosts, ["leaf1", "leaf2"])
 
+    def test_parse_args_hosts_file(self):
+        args = update_vtep.parse_args(["-u", "admin", "-f", "hosts.txt", "leaf1"])
+        self.assertEqual(args.username, "admin")
+        self.assertEqual(args.hosts_file, "hosts.txt")
+        self.assertEqual(args.hosts, ["leaf1"])
+
 
 class ResolveHostsTest(unittest.TestCase):
     @patch("arista_vtep_update.socket.gethostbyname")
@@ -112,6 +118,37 @@ class MainTest(unittest.TestCase):
 
         self.assertEqual(result, 0)
         self.assertEqual(mock_send.call_count, 2)
+        mock_send.assert_any_call(
+            host="leaf1",
+            username="admin",
+            password="pass",
+            commands=update_vtep.build_flood_commands(["192.0.2.2"]),
+            verify_ssl=False,
+        )
+        mock_send.assert_any_call(
+            host="leaf2",
+            username="admin",
+            password="pass",
+            commands=update_vtep.build_flood_commands(["192.0.2.1"]),
+            verify_ssl=False,
+        )
+
+    @patch("builtins.print")
+    @patch("arista_vtep_update.send_eapi_commands")
+    @patch("arista_vtep_update.resolve_hosts")
+    @patch("arista_vtep_update.getpass", return_value="pass")
+    @patch("arista_vtep_update.ThreadPoolExecutor", new=SynchronousExecutor)
+    def test_main_hosts_file(self, mock_getpass, mock_resolve, mock_send, mock_print):
+        mock_resolve.return_value = ["192.0.2.1", "192.0.2.2"]
+        mock_send.return_value = {"result": "ok"}
+
+        m = unittest.mock.mock_open(read_data="leaf1\nleaf2\n")
+        with patch("builtins.open", m):
+            result = update_vtep.main(["-u", "admin", "--use-eapi", "-f", "hosts.txt"])
+
+        self.assertEqual(result, 0)
+        self.assertEqual(mock_send.call_count, 2)
+        m.assert_called_once_with("hosts.txt")
         mock_send.assert_any_call(
             host="leaf1",
             username="admin",


### PR DESCRIPTION
## Summary
- allow specifying hosts via a file
- document the new --hosts-file flag
- test new file input feature

## Testing
- `pytest -q`