### PR TITLE
Support configurable VXLAN interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 Utility for statically configuring VXLAN VTEP flood lists on Arista switches.
 By default the script connects via SSH but eAPI can be used as an optional
-transport. `Vxlan1` on each switch is updated so that all provided devices are
-configured as remote VTEP endpoints.
+transport. By default `Vxlan1` on each switch is updated so that all provided
+devices are configured as remote VTEP endpoints, but a different interface can
+be specified with `--interface`.
 
 ## Requirements
 
@@ -27,7 +28,7 @@ pip install .
 ## Usage
 
 ```
-arista-vtep-update -u <username> [--use-eapi] [--verify-ssl] [--hosts-file FILE] <host1> <host2> [host3 ...]
+arista-vtep-update -u <username> [--use-eapi] [--verify-ssl] [--hosts-file FILE] [--interface VXLAN] <host1> <host2> [host3 ...]
 ```
 
 The script prompts for the password. At least two hosts must be supplied.

--- a/arista_vtep_update/__init__.py
+++ b/arista_vtep_update/__init__.py
@@ -93,8 +93,8 @@ def send_ssh_commands(
     return out
 
 
-def build_flood_commands(remote_vtep_ips: List[str]) -> List[str]:
-    """Build CLI commands to update the Vxlan1 flood list.
+def build_flood_commands(remote_vtep_ips: List[str], interface: str = "Vxlan1") -> List[str]:
+    """Build CLI commands to update the VXLAN interface flood list.
 
     Parameters
     ----------
@@ -107,7 +107,7 @@ def build_flood_commands(remote_vtep_ips: List[str]) -> List[str]:
         Commands ready to be sent to the switch.
     """
 
-    commands = ["interface Vxlan1"]
+    commands = [f"interface {interface}"]
     # Clear any existing flood list entries so only the desired VTEPs remain.
     # 'no vxlan flood vtep' removes all currently configured remote VTEP
     # addresses from the list.
@@ -120,7 +120,7 @@ def build_flood_commands(remote_vtep_ips: List[str]) -> List[str]:
 
 def parse_args(argv: List[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Update Vxlan1 flood list on multiple Arista switches"
+        description="Update VXLAN interface flood list on multiple Arista switches"
     )
     parser.add_argument(
         "hosts",
@@ -147,6 +147,12 @@ def parse_args(argv: List[str]) -> argparse.Namespace:
         "--use-eapi",
         action="store_true",
         help="Use eAPI instead of SSH",
+    )
+    parser.add_argument(
+        "-i",
+        "--interface",
+        default="Vxlan1",
+        help="VXLAN interface to update (default: Vxlan1)",
     )
     return parser.parse_args(argv)
 
@@ -239,7 +245,7 @@ def main(argv: List[str]) -> int:
 
         def worker(host: str, ip: str):
             remote_vteps = [other for other in ips if other != ip]
-            commands = build_flood_commands(remote_vteps)
+            commands = build_flood_commands(remote_vteps, interface=args.interface)
             if args.use_eapi:
                 result = send_eapi_commands(
                     host=host,

--- a/tests/test_update_vtep.py
+++ b/tests/test_update_vtep.py
@@ -48,6 +48,19 @@ class BuildFloodCommandsTest(unittest.TestCase):
         ]
         self.assertEqual(update_vtep.build_flood_commands(remote), expected)
 
+    def test_build_flood_commands_custom_interface(self):
+        remote = ["1.1.1.1"]
+        expected = [
+            "interface Vxlan100",
+            "no vxlan flood vtep",
+            "vxlan flood vtep 1.1.1.1",
+            "exit",
+        ]
+        self.assertEqual(
+            update_vtep.build_flood_commands(remote, interface="Vxlan100"),
+            expected,
+        )
+
 
 class ParseArgsTest(unittest.TestCase):
     def test_parse_args(self):
@@ -55,12 +68,24 @@ class ParseArgsTest(unittest.TestCase):
         self.assertEqual(args.username, "admin")
         self.assertTrue(args.verify_ssl)
         self.assertEqual(args.hosts, ["leaf1", "leaf2"])
+        self.assertEqual(args.interface, "Vxlan1")
 
     def test_parse_args_hosts_file(self):
         args = update_vtep.parse_args(["-u", "admin", "-f", "hosts.txt", "leaf1"])
         self.assertEqual(args.username, "admin")
         self.assertEqual(args.hosts_file, "hosts.txt")
         self.assertEqual(args.hosts, ["leaf1"])
+
+    def test_parse_args_custom_interface(self):
+        args = update_vtep.parse_args([
+            "-u",
+            "admin",
+            "-i",
+            "Vxlan100",
+            "leaf1",
+            "leaf2",
+        ])
+        self.assertEqual(args.interface, "Vxlan100")
 
 
 class ResolveHostsTest(unittest.TestCase):


### PR DESCRIPTION
## Summary
- allow specifying a VXLAN interface via `--interface`
- update CLI help and README
- add tests for new option

## Testing
- `pytest -q`